### PR TITLE
Fix: Ensure API requests include /v4 prefix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jikanrb (0.2.1)
+    jikanrb (0.2.2)
       faraday (>= 2.0, < 3.0)
       faraday-retry (>= 2.0, < 3.0)
 

--- a/bin/console
+++ b/bin/console
@@ -8,4 +8,6 @@ require 'jikanrb'
 # with your gem easier. You can also use a different console, if you like.
 
 require 'irb'
+require 'debug'
+
 IRB.start(__FILE__)

--- a/lib/jikanrb/client.rb
+++ b/lib/jikanrb/client.rb
@@ -53,7 +53,7 @@ module Jikanrb
     # @param full [Boolean] If true, returns extended information
     # @return [Hash] Anime data
     def anime(id, full: false)
-      path = full ? "/anime/#{id}/full" : "/anime/#{id}"
+      path = full ? "anime/#{id}/full" : "anime/#{id}"
       get(path)
     end
 
@@ -63,7 +63,7 @@ module Jikanrb
     # @param full [Boolean] If true, returns extended information
     # @return [Hash] Manga data
     def manga(id, full: false)
-      path = full ? "/manga/#{id}/full" : "/manga/#{id}"
+      path = full ? "manga/#{id}/full" : "manga/#{id}"
       get(path)
     end
 
@@ -73,7 +73,7 @@ module Jikanrb
     # @param full [Boolean] If true, returns extended information
     # @return [Hash] Character data
     def character(id, full: false)
-      path = full ? "/characters/#{id}/full" : "/characters/#{id}"
+      path = full ? "characters/#{id}/full" : "characters/#{id}"
       get(path)
     end
 
@@ -83,7 +83,7 @@ module Jikanrb
     # @param full [Boolean] If true, returns extended information
     # @return [Hash] Person data
     def person(id, full: false)
-      path = full ? "/people/#{id}/full" : "/people/#{id}"
+      path = full ? "people/#{id}/full" : "people/#{id}"
       get(path)
     end
 
@@ -93,7 +93,7 @@ module Jikanrb
     # @param params [Hash] Additional filters (type, score, status, etc.)
     # @return [Hash] Search results
     def search_anime(query, **params)
-      get('/anime', params.merge(q: query))
+      get('anime', params.merge(q: query))
     end
 
     # Search manga
@@ -102,7 +102,7 @@ module Jikanrb
     # @param params [Hash] Additional filters
     # @return [Hash] Search results
     def search_manga(query, **params)
-      get('/manga', params.merge(q: query))
+      get('manga', params.merge(q: query))
     end
 
     # Top anime
@@ -115,7 +115,7 @@ module Jikanrb
       params = { page: page }
       params[:type] = type if type
       params[:filter] = filter if filter
-      get('/top/anime', params)
+      get('top/anime', params)
     end
 
     # Top manga
@@ -128,7 +128,7 @@ module Jikanrb
       params = { page: page }
       params[:type] = type if type
       params[:filter] = filter if filter
-      get('/top/manga', params)
+      get('top/manga', params)
     end
 
     # Seasonal anime
@@ -138,7 +138,7 @@ module Jikanrb
     # @param page [Integer] Page number
     # @return [Hash] Seasonal anime
     def season(year, season, page: 1)
-      get("/seasons/#{year}/#{season}", page: page)
+      get("seasons/#{year}/#{season}", page: page)
     end
 
     # Current season
@@ -146,7 +146,7 @@ module Jikanrb
     # @param page [Integer] Page number
     # @return [Hash] Current season anime
     def season_now(page: 1)
-      get('/seasons/now', page: page)
+      get('seasons/now', page: page)
     end
 
     # Weekly schedule
@@ -154,7 +154,7 @@ module Jikanrb
     # @param day [String, nil] Day: "monday", "tuesday", etc.
     # @return [Hash] Anime schedule
     def schedules(day: nil)
-      path = day ? "/schedules/#{day}" : '/schedules'
+      path = day ? "schedules/#{day}" : 'schedules'
       get(path)
     end
 

--- a/lib/jikanrb/configuration.rb
+++ b/lib/jikanrb/configuration.rb
@@ -10,7 +10,7 @@ module Jikanrb
   #   config.max_retries = 5
   class Configuration
     # Base URL for Jikan v4 API
-    DEFAULT_BASE_URL = 'https://api.jikan.moe/v4/'
+    DEFAULT_BASE_URL = 'https://api.jikan.moe/v4'
 
     # Default timeouts (in seconds)
     DEFAULT_OPEN_TIMEOUT = 5

--- a/lib/jikanrb/configuration.rb
+++ b/lib/jikanrb/configuration.rb
@@ -10,7 +10,7 @@ module Jikanrb
   #   config.max_retries = 5
   class Configuration
     # Base URL for Jikan v4 API
-    DEFAULT_BASE_URL = 'https://api.jikan.moe/v4'
+    DEFAULT_BASE_URL = 'https://api.jikan.moe/v4/'
 
     # Default timeouts (in seconds)
     DEFAULT_OPEN_TIMEOUT = 5

--- a/lib/jikanrb/version.rb
+++ b/lib/jikanrb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Jikanrb
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/spec/jikanrb/client_spec.rb
+++ b/spec/jikanrb/client_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Jikanrb::Client do
   subject(:client) { described_class.new }
 
-  let(:base_url) { 'https://api.jikan.moe' }
+  let(:base_url) { 'https://api.jikan.moe/v4' }
 
   describe '#initialize' do
     it 'creates a new configuration' do
@@ -400,7 +400,7 @@ RSpec.describe Jikanrb::Client do
           .to_return(status: 400, body: '', headers: {})
 
         expect do
-          client.get('/anime', { invalid_param: 'bad value' })
+          client.get('anime', { invalid_param: 'bad value' })
         end.to raise_error(Jikanrb::BadRequestError)
       end
     end

--- a/spec/jikanrb/pagination_spec.rb
+++ b/spec/jikanrb/pagination_spec.rb
@@ -199,13 +199,13 @@ RSpec.describe Jikanrb::Pagination do
     end
 
     before do
-      stub_request(:get, 'https://api.jikan.moe/top/anime?page=1')
+      stub_request(:get, 'https://api.jikan.moe/v4/top/anime?page=1')
         .to_return(status: 200, body: page1_response.to_json, headers: { 'Content-Type' => 'application/json' })
 
-      stub_request(:get, 'https://api.jikan.moe/top/anime?page=2')
+      stub_request(:get, 'https://api.jikan.moe/v4/top/anime?page=2')
         .to_return(status: 200, body: page2_response.to_json, headers: { 'Content-Type' => 'application/json' })
 
-      stub_request(:get, 'https://api.jikan.moe/top/anime?page=3')
+      stub_request(:get, 'https://api.jikan.moe/v4/top/anime?page=3')
         .to_return(status: 200, body: page3_response.to_json, headers: { 'Content-Type' => 'application/json' })
     end
 


### PR DESCRIPTION
This PR fixes a bug where Jikan API requests were missing the /v4 version segment in the URL. It also bumps the version to 0.2.2.