### PR TITLE
feat: Fluent API for sub-resources (v0.3.0)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(rubocop:*)",
-      "Bash(bundle exec rubocop:*)"
+      "Bash(bundle exec rubocop:*)",
+      "mcp__acp__Bash"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(rubocop:*)",
-      "Bash(bundle exec rubocop:*)",
-      "mcp__acp__Bash"
-    ]
-  }
-}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rspec
+
+      - name: Run RuboCop
+        run: bundle exec rubocop
+
+      - name: Build gem
+        run: gem build jikanrb.gemspec
+
+      - name: Publish to RubyGems
+        run: |
+          mkdir -p ~/.gem
+          echo -e "---\n:rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}" > ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+          gem push jikanrb-*.gem

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@
 .rspec_status
 
 # AI
-.claude
-.agent
+.claude/
+.agent/
 
 # Editor helpers
 .ruby-lsp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,72 @@
 ## [Unreleased]
 
+## [0.3.0] - 2026-01-31
+
+### Added
+- **Fluent API** for accessing sub-resources with chainable methods
+- `BaseResource` class providing common functionality for all resources
+- `AnimeResource` with 14 sub-resource methods:
+  - `info(full: false)` - Basic/full anime details
+  - `characters` - Characters and voice actors
+  - `staff` - Staff members
+  - `episodes(page: nil)` - Episodes with pagination
+  - `news` - Related news articles
+  - `forum` - Forum topics
+  - `videos` - PVs, episodes, music videos
+  - `pictures` - Anime pictures
+  - `statistics` - User statistics
+  - `recommendations` - User recommendations
+  - `relations` - Related anime/manga
+  - `themes` - Opening/ending themes
+  - `external` - External links
+  - `streaming` - Streaming platform links
+- `MangaResource` with 9 sub-resource methods:
+  - `info(full: false)` - Basic/full manga details
+  - `characters` - Characters
+  - `news` - Related news articles
+  - `forum` - Forum topics
+  - `pictures` - Manga pictures
+  - `statistics` - User statistics
+  - `recommendations` - User recommendations
+  - `relations` - Related anime/manga
+  - `external` - External links
+- `CharacterResource` with 5 sub-resource methods:
+  - `info(full: false)` - Basic/full character details
+  - `animes` - Anime appearances
+  - `mangas` - Manga appearances
+  - `voices` - Voice actors
+  - `pictures` - Character pictures
+- `PersonResource` with 5 sub-resource methods:
+  - `info(full: false)` - Basic/full person details
+  - `animes` - Anime staff positions
+  - `mangas` - Manga work
+  - `voices` - Voice acting roles
+  - `pictures` - Person pictures
+
+### Changed
+- `Client#anime(id)` now returns `AnimeResource` instead of `Hash`
+- `Client#manga(id)` now returns `MangaResource` instead of `Hash`
+- `Client#character(id)` now returns `CharacterResource` instead of `Hash`
+- `Client#person(id)` now returns `PersonResource` instead of `Hash`
+
+### Breaking Changes
+- Removed `full:` parameter from `anime`, `manga`, `character`, and `person` methods
+- Use `.info` or `.info(full: true)` for the previous behavior:
+  ```ruby
+  # Before (v0.2.x)
+  client.anime(1)
+  client.anime(1, full: true)
+
+  # After (v0.3.0+)
+  client.anime(1).info
+  client.anime(1).info(full: true)
+  ```
+
+### Documentation
+- Complete YARD documentation for all resource classes
+- Updated README with fluent API examples
+- Added migration guide for breaking changes
+
 ## [0.2.1] - 2026-01-10
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jikanrb (0.2.2)
+    jikanrb (0.3.0)
       faraday (>= 2.0, < 3.0)
       faraday-retry (>= 2.0, < 3.0)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Jikanrb
 
 [![Gem Version](https://badge.fury.io/rb/jikanrb.svg)](https://badge.fury.io/rb/jikanrb)
-[![CI](https://github.com/tuusuario/jikanrb/actions/workflows/main.yml/badge.svg)](https://github.com/tuusuario/jikanrb/actions)
+[![CI](https://github.com/sbrocos/jikanrb/actions/workflows/main.yml/badge.svg)](https://github.com/sbrocos/jikanrb/actions)
 
 A modern Ruby client for the [Jikan API v4](https://jikan.moe/) - the unofficial MyAnimeList API.
 
@@ -10,7 +10,7 @@ A modern Ruby client for the [Jikan API v4](https://jikan.moe/) - the unofficial
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'jikanrb'
+gem "jikanrb"
 ```
 
 And then execute:
@@ -30,17 +30,14 @@ gem install jikanrb
 ### Quick Start
 
 ```ruby
-require 'jikanrb'
+require "jikanrb"
 
-# Get anime by ID
-anime = Jikanrb.anime(1)
-
-# Access data using strings or symbols (Indifferent Access)
-puts anime["data"]["title"] # => "Cowboy Bebop"
-puts anime[:data][:title]   # => "Cowboy Bebop"
+# Get anime info using fluent API
+anime = Jikanrb.anime(1).info
+puts anime[:data][:title]  # => "Cowboy Bebop"
 
 # Get full anime info (includes relations, theme songs, etc.)
-anime = Jikanrb.anime(1, full: true)
+anime = Jikanrb.anime(1).info(full: true)
 
 # Search anime
 results = Jikanrb.search_anime("Naruto")
@@ -57,11 +54,13 @@ client = Jikanrb::Client.new do |config|
   config.max_retries = 5
 end
 
-# All methods available
-client.anime(1)
-client.manga(1)
-client.character(1)
-client.person(1)
+# Fluent API for resources
+client.anime(1).info
+client.manga(1).info
+client.character(1).info
+client.person(1).info
+
+# Search and listings
 client.search_anime("One Piece", type: "tv", status: "airing")
 client.top_anime(type: "tv", filter: "bypopularity")
 client.season(2024, "winter")
@@ -69,18 +68,74 @@ client.season_now
 client.schedules(day: "monday")
 ```
 
-### Configuration in Rails
+## Fluent API (v1.1.0+)
 
-You can configure the gem globally in an initializer (e.g., `config/initializers/jikanrb.rb`):
+Access sub-resources using the fluent interface for cleaner, chainable code.
+
+### Anime
 
 ```ruby
-# config/initializers/jikanrb.rb
-Jikanrb.configure do |config|
-  config.read_timeout = 20
-  config.max_retries = 3
-  # config.logger = Rails.logger # Use Rails logger
-end
+client = Jikanrb::Client.new
+
+# Basic and full info
+client.anime(1).info                # GET /anime/1
+client.anime(1).info(full: true)    # GET /anime/1/full
+
+# Sub-resources
+client.anime(1).characters          # Characters and voice actors
+client.anime(1).staff               # Staff members
+client.anime(1).episodes            # Episodes (first page)
+client.anime(1).episodes(page: 2)   # Episodes (page 2)
+client.anime(1).news                # News articles
+client.anime(1).forum               # Forum topics
+client.anime(1).videos              # PVs, episodes, music videos
+client.anime(1).pictures            # Pictures
+client.anime(1).statistics          # User statistics
+client.anime(1).recommendations     # User recommendations
+client.anime(1).relations           # Related anime/manga
+client.anime(1).themes              # Opening/ending themes
+client.anime(1).external            # External links
+client.anime(1).streaming           # Streaming platform links
 ```
+
+### Manga
+
+```ruby
+client.manga(1).info                # GET /manga/1
+client.manga(1).info(full: true)    # GET /manga/1/full
+client.manga(1).characters          # Characters
+client.manga(1).news                # News articles
+client.manga(1).forum               # Forum topics
+client.manga(1).pictures            # Pictures
+client.manga(1).statistics          # User statistics
+client.manga(1).recommendations     # User recommendations
+client.manga(1).relations           # Related anime/manga
+client.manga(1).external            # External links
+```
+
+### Characters
+
+```ruby
+client.character(1).info            # GET /characters/1
+client.character(1).info(full: true)# GET /characters/1/full
+client.character(1).animes          # Anime appearances
+client.character(1).mangas          # Manga appearances
+client.character(1).voices          # Voice actors
+client.character(1).pictures        # Pictures
+```
+
+### People
+
+```ruby
+client.person(1).info               # GET /people/1
+client.person(1).info(full: true)   # GET /people/1/full
+client.person(1).animes             # Anime staff positions
+client.person(1).mangas             # Manga work
+client.person(1).voices             # Voice acting roles
+client.person(1).pictures           # Pictures
+```
+
+## Configuration
 
 ### Global Configuration
 
@@ -95,14 +150,33 @@ Jikanrb.configure do |config|
 end
 ```
 
-### Available Methods
+### Rails Configuration
+
+Create an initializer (e.g., `config/initializers/jikanrb.rb`):
+
+```ruby
+Jikanrb.configure do |config|
+  config.read_timeout = 20
+  config.max_retries = 3
+  config.logger = Rails.logger
+end
+```
+
+## Available Methods
+
+### Resource Methods (Fluent API)
+
+| Method | Returns | Description |
+| :--- | :--- | :--- |
+| `anime(id)` | `AnimeResource` | Anime resource for sub-resource access |
+| `manga(id)` | `MangaResource` | Manga resource for sub-resource access |
+| `character(id)` | `CharacterResource` | Character resource for sub-resource access |
+| `person(id)` | `PersonResource` | Person resource for sub-resource access |
+
+### Direct Methods
 
 | Method | Description |
 | :--- | :--- |
-| `anime(id, full: false)` | Get anime by MAL ID |
-| `manga(id, full: false)` | Get manga by MAL ID |
-| `character(id, full: false)` | Get character by MAL ID |
-| `person(id, full: false)` | Get person by MAL ID |
 | `search_anime(query, **params)` | Search anime |
 | `search_manga(query, **params)` | Search manga |
 | `top_anime(type:, filter:, page:)` | Top anime list |
@@ -111,11 +185,11 @@ end
 | `season_now(page:)` | Current season anime |
 | `schedules(day:)` | Weekly schedule |
 
-### Error Handling
+## Error Handling
 
 ```ruby
 begin
-  anime = Jikanrb.anime(999999999)
+  anime = Jikanrb.anime(999999999).info
 rescue Jikanrb::NotFoundError => e
   puts "Anime not found: #{e.message}"
 rescue Jikanrb::RateLimitError => e
@@ -127,21 +201,22 @@ rescue Jikanrb::Error => e
 end
 ```
 
-### Pagination
+## Pagination
 
 The gem provides convenient pagination helpers for working with paginated endpoints:
 
 ```ruby
-# Automatic pagination - iterates through all pages
 client = Jikanrb::Client.new
-paginator = client.paginate(:top_anime, type: 'tv')
+
+# Automatic pagination - iterates through all pages
+paginator = client.paginate(:top_anime, type: "tv")
 
 # Get all items (will fetch all pages)
 all_anime = paginator.all
 
 # Iterate through all pages lazily
 paginator.each do |anime|
-  puts "#{anime['title']} - Score: #{anime['score']}"
+  puts "#{anime["title"]} - Score: #{anime["score"]}"
 end
 
 # Get items from first 3 pages only
@@ -153,23 +228,14 @@ pagination = client.pagination_info(response)
 
 puts "Current page: #{pagination.current_page}"
 puts "Total pages: #{pagination.total_pages}"
-puts "Items per page: #{pagination.per_page}"
 puts "Has next page: #{pagination.has_next_page?}"
-puts "Has previous page: #{pagination.has_previous_page?}"
-puts "Next page number: #{pagination.next_page}" if pagination.has_next_page?
 ```
 
-### Rate Limiting
+## Rate Limiting
 
 Jikan API allows **60 requests per minute**. This gem includes automatic retry with exponential backoff for rate limit errors (429).
 
 ## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-### Useful Commands
 
 ```bash
 # Install dependencies
@@ -178,11 +244,14 @@ bin/setup
 # Run tests
 bundle exec rspec
 
+# Run linter
+bundle exec rubocop
+
 # Interactive console
 bin/console
 
-# Linting
-bundle exec rubocop
+# Generate documentation
+bundle exec yard doc
 ```
 
 ## Acknowledgments
@@ -191,12 +260,8 @@ This gem is inspired by [jikan.rb](https://github.com/Zerocchi/jikan.rb) by Zero
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at <https://github.com/[USERNAME]/jikanrb>. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/jikanrb/blob/main/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/sbrocos/jikanrb.
 
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-
-## Code of Conduct
-
-Everyone interacting in the Jikanrb project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/jikanrb/blob/main/CODE_OF_CONDUCT.md).

--- a/lib/jikanrb.rb
+++ b/lib/jikanrb.rb
@@ -7,6 +7,9 @@ require_relative 'jikanrb/pagination'
 require_relative 'jikanrb/client'
 require_relative 'jikanrb/utils'
 
+# Resources module - Fluent API for accessing sub-resources
+require_relative 'jikanrb/resources/base_resource'
+
 # Jikanrb is a modern Ruby wrapper for the Jikan REST API v4.
 # Provides easy access to anime, manga, characters, and more from MyAnimeList.
 #

--- a/lib/jikanrb.rb
+++ b/lib/jikanrb.rb
@@ -9,6 +9,8 @@ require_relative 'jikanrb/utils'
 
 # Resources module - Fluent API for accessing sub-resources
 require_relative 'jikanrb/resources/base_resource'
+require_relative 'jikanrb/resources/character_resource'
+require_relative 'jikanrb/resources/person_resource'
 
 # Jikanrb is a modern Ruby wrapper for the Jikan REST API v4.
 # Provides easy access to anime, manga, characters, and more from MyAnimeList.
@@ -82,13 +84,13 @@ module Jikanrb
     end
 
     # @see Client#character
-    def character(id, full: false)
-      client.character(id, full: full)
+    def character(id)
+      client.character(id)
     end
 
     # @see Client#person
-    def person(id, full: false)
-      client.person(id, full: full)
+    def person(id)
+      client.person(id)
     end
 
     # @see Client#search_anime

--- a/lib/jikanrb.rb
+++ b/lib/jikanrb.rb
@@ -9,6 +9,8 @@ require_relative 'jikanrb/utils'
 
 # Resources module - Fluent API for accessing sub-resources
 require_relative 'jikanrb/resources/base_resource'
+require_relative 'jikanrb/resources/anime_resource'
+require_relative 'jikanrb/resources/manga_resource'
 require_relative 'jikanrb/resources/character_resource'
 require_relative 'jikanrb/resources/person_resource'
 
@@ -74,13 +76,13 @@ module Jikanrb
     # Allows using Jikanrb.anime(1) directly
 
     # @see Client#anime
-    def anime(id, full: false)
-      client.anime(id, full: full)
+    def anime(id)
+      client.anime(id)
     end
 
     # @see Client#manga
-    def manga(id, full: false)
-      client.manga(id, full: full)
+    def manga(id)
+      client.manga(id)
     end
 
     # @see Client#character

--- a/lib/jikanrb/client.rb
+++ b/lib/jikanrb/client.rb
@@ -47,24 +47,46 @@ module Jikanrb
       request(:get, path, params)
     end
 
-    # Anime information by ID
+    # Returns an AnimeResource for fluent API access to anime sub-resources
     #
     # @param id [Integer] Anime ID on MyAnimeList
-    # @param full [Boolean] If true, returns extended information
-    # @return [Hash] Anime data
-    def anime(id, full: false)
-      path = full ? "anime/#{id}/full" : "anime/#{id}"
-      get(path)
+    # @return [Resources::AnimeResource] Anime resource for chaining
+    #
+    # @example Get anime info
+    #   client.anime(1).info
+    #   # => { data: { mal_id: 1, title: "Cowboy Bebop", ... } }
+    #
+    # @example Get full anime info
+    #   client.anime(1).info(full: true)
+    #
+    # @example Get anime characters
+    #   client.anime(1).characters
+    #
+    # @example Get anime episodes
+    #   client.anime(1).episodes
+    def anime(id)
+      Resources::AnimeResource.new(self, id)
     end
 
-    # Manga information by ID
+    # Returns a MangaResource for fluent API access to manga sub-resources
     #
     # @param id [Integer] Manga ID on MyAnimeList
-    # @param full [Boolean] If true, returns extended information
-    # @return [Hash] Manga data
-    def manga(id, full: false)
-      path = full ? "manga/#{id}/full" : "manga/#{id}"
-      get(path)
+    # @return [Resources::MangaResource] Manga resource for chaining
+    #
+    # @example Get manga info
+    #   client.manga(1).info
+    #   # => { data: { mal_id: 1, title: "Monster", ... } }
+    #
+    # @example Get full manga info
+    #   client.manga(1).info(full: true)
+    #
+    # @example Get manga characters
+    #   client.manga(1).characters
+    #
+    # @example Get manga statistics
+    #   client.manga(1).statistics
+    def manga(id)
+      Resources::MangaResource.new(self, id)
     end
 
     # Returns a CharacterResource for fluent API access to character sub-resources

--- a/lib/jikanrb/client.rb
+++ b/lib/jikanrb/client.rb
@@ -67,24 +67,46 @@ module Jikanrb
       get(path)
     end
 
-    # Character information by ID
+    # Returns a CharacterResource for fluent API access to character sub-resources
     #
     # @param id [Integer] Character ID on MyAnimeList
-    # @param full [Boolean] If true, returns extended information
-    # @return [Hash] Character data
-    def character(id, full: false)
-      path = full ? "characters/#{id}/full" : "characters/#{id}"
-      get(path)
+    # @return [Resources::CharacterResource] Character resource for chaining
+    #
+    # @example Get character info
+    #   client.character(1).info
+    #   # => { data: { mal_id: 1, name: "Spike Spiegel", ... } }
+    #
+    # @example Get full character info
+    #   client.character(1).info(full: true)
+    #
+    # @example Get character's anime appearances
+    #   client.character(1).animes
+    #
+    # @example Get character's voice actors
+    #   client.character(1).voices
+    def character(id)
+      Resources::CharacterResource.new(self, id)
     end
 
-    # Person information by ID
+    # Returns a PersonResource for fluent API access to person sub-resources
     #
     # @param id [Integer] Person ID on MyAnimeList
-    # @param full [Boolean] If true, returns extended information
-    # @return [Hash] Person data
-    def person(id, full: false)
-      path = full ? "people/#{id}/full" : "people/#{id}"
-      get(path)
+    # @return [Resources::PersonResource] Person resource for chaining
+    #
+    # @example Get person info
+    #   client.person(1).info
+    #   # => { data: { mal_id: 1, name: "Tomokazu Seki", ... } }
+    #
+    # @example Get full person info
+    #   client.person(1).info(full: true)
+    #
+    # @example Get person's anime staff positions
+    #   client.person(1).animes
+    #
+    # @example Get person's voice acting roles
+    #   client.person(1).voices
+    def person(id)
+      Resources::PersonResource.new(self, id)
     end
 
     # Search anime

--- a/lib/jikanrb/resources/anime_resource.rb
+++ b/lib/jikanrb/resources/anime_resource.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+module Jikanrb
+  module Resources
+    # Resource class for accessing Anime sub-resources from the Jikan API.
+    # Provides fluent API access to anime details, characters, staff, episodes,
+    # news, forum topics, videos, pictures, statistics, and more.
+    #
+    # @example Basic usage
+    #   client = Jikanrb::Client.new
+    #   anime = client.anime(1)
+    #   anime.info                   # GET /anime/1
+    #   anime.info(full: true)       # GET /anime/1/full
+    #   anime.characters             # GET /anime/1/characters
+    #   anime.episodes               # GET /anime/1/episodes
+    #
+    # @see https://docs.api.jikan.moe/#tag/anime
+    class AnimeResource < BaseResource
+      # Returns anime details
+      #
+      # @param full [Boolean] If true, returns extended information including
+      #   relations, themes, external links, and streaming links
+      # @return [Hash] Anime data as IndifferentHash
+      #
+      # @example Get basic info
+      #   client.anime(1).info
+      #   # => { data: { mal_id: 1, title: "Cowboy Bebop", ... } }
+      #
+      # @example Get full info
+      #   client.anime(1).info(full: true)
+      #   # => { data: { mal_id: 1, title: "...", relations: [...], themes: {...} } }
+      def info(full: false)
+        path = full ? "anime/#{@id}/full" : "anime/#{@id}"
+        get(path)
+      end
+
+      # Returns characters and their voice actors for this anime
+      #
+      # @return [Hash] List of characters as IndifferentHash
+      #
+      # @example
+      #   client.anime(1).characters
+      #   # => { data: [{ character: { mal_id: 1, name: "Spike Spiegel" }, role: "Main", voice_actors: [...] }, ...] }
+      def characters
+        get("anime/#{@id}/characters")
+      end
+
+      # Returns staff members for this anime
+      #
+      # @return [Hash] List of staff as IndifferentHash
+      #
+      # @example
+      #   client.anime(1).staff
+      #   # => { data: [{ person: { mal_id: 1, name: "..." }, positions: ["Director"] }, ...] }
+      def staff
+        get("anime/#{@id}/staff")
+      end
+
+      # Returns episodes for this anime
+      #
+      # @param page [Integer, nil] Page number for pagination
+      # @return [Hash] List of episodes as IndifferentHash
+      #
+      # @example Get first page of episodes
+      #   client.anime(1).episodes
+      #   # => { data: [{ mal_id: 1, title: "Asteroid Blues", ... }, ...], pagination: { ... } }
+      #
+      # @example Get specific page
+      #   client.anime(1).episodes(page: 2)
+      def episodes(page: nil)
+        get("anime/#{@id}/episodes", { page: page }.compact)
+      end
+
+      # Returns news articles related to this anime
+      #
+      # @return [Hash] List of news articles as IndifferentHash
+      #
+      # @example
+      #   client.anime(1).news
+      #   # => { data: [{ mal_id: 1, title: "...", date: "...", author_username: "..." }, ...] }
+      def news
+        get("anime/#{@id}/news")
+      end
+
+      # Returns forum topics related to this anime
+      #
+      # @return [Hash] List of forum topics as IndifferentHash
+      #
+      # @example
+      #   client.anime(1).forum
+      #   # => { data: [{ mal_id: 1, title: "...", date: "...", author_username: "..." }, ...] }
+      def forum
+        get("anime/#{@id}/forum")
+      end
+
+      # Returns videos (PVs, episodes, music videos) for this anime
+      #
+      # @return [Hash] Video data as IndifferentHash
+      #
+      # @example
+      #   client.anime(1).videos
+      #   # => { data: { promo: [...], episodes: [...], music_videos: [...] } }
+      def videos
+        get("anime/#{@id}/videos")
+      end
+
+      # Returns pictures of this anime
+      #
+      # @return [Hash] List of pictures as IndifferentHash
+      #
+      # @example
+      #   client.anime(1).pictures
+      #   # => { data: [{ jpg: { image_url: "https://..." }, webp: { ... } }, ...] }
+      def pictures
+        get("anime/#{@id}/pictures")
+      end
+
+      # Returns statistics for this anime
+      #
+      # @return [Hash] Statistics data as IndifferentHash
+      #
+      # @example
+      #   client.anime(1).statistics
+      #   # => { data: { watching: 12345, completed: 67890, on_hold: 1234, ... } }
+      def statistics
+        get("anime/#{@id}/statistics")
+      end
+
+      # Returns user recommendations for this anime
+      #
+      # @return [Hash] List of recommendations as IndifferentHash
+      #
+      # @example
+      #   client.anime(1).recommendations
+      #   # => { data: [{ entry: { mal_id: 5, title: "..." }, votes: 123 }, ...] }
+      def recommendations
+        get("anime/#{@id}/recommendations")
+      end
+
+      # Returns related anime/manga entries
+      #
+      # @return [Hash] List of relations as IndifferentHash
+      #
+      # @example
+      #   client.anime(1).relations
+      #   # => { data: [{ relation: "Adaptation", entry: [{ mal_id: 173, type: "manga", name: "..." }] }, ...] }
+      def relations
+        get("anime/#{@id}/relations")
+      end
+
+      # Returns opening and ending themes for this anime
+      #
+      # @return [Hash] Theme songs as IndifferentHash
+      #
+      # @example
+      #   client.anime(1).themes
+      #   # => { data: { openings: ["Tank! by The Seatbelts"], endings: ["The Real Folk Blues by ..."] } }
+      def themes
+        get("anime/#{@id}/themes")
+      end
+
+      # Returns external links for this anime
+      #
+      # @return [Hash] List of external links as IndifferentHash
+      #
+      # @example
+      #   client.anime(1).external
+      #   # => { data: [{ name: "Official Site", url: "https://..." }, ...] }
+      def external
+        get("anime/#{@id}/external")
+      end
+
+      # Returns streaming links for this anime
+      #
+      # @return [Hash] List of streaming platforms as IndifferentHash
+      #
+      # @example
+      #   client.anime(1).streaming
+      #   # => { data: [{ name: "Crunchyroll", url: "https://..." }, ...] }
+      def streaming
+        get("anime/#{@id}/streaming")
+      end
+    end
+  end
+end

--- a/lib/jikanrb/resources/base_resource.rb
+++ b/lib/jikanrb/resources/base_resource.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Jikanrb
+  module Resources
+    # Base class for all resource classes.
+    # Provides common functionality for accessing sub-resources from the Jikan API.
+    #
+    # @abstract Subclass and implement specific resource methods
+    #
+    # @example Creating a custom resource
+    #   class AnimeResource < BaseResource
+    #     def characters
+    #       get("anime/#{@id}/characters")
+    #     end
+    #   end
+    class BaseResource
+      # @return [Integer] The resource ID
+      attr_reader :id
+
+      # Creates a new resource instance
+      #
+      # @param client [Jikanrb::Client] The client instance to use for requests
+      # @param id [Integer] The resource ID on MyAnimeList
+      def initialize(client, id)
+        @client = client
+        @id = id
+      end
+
+      private
+
+      # Performs a GET request through the client
+      #
+      # @param path [String] The API endpoint path
+      # @param params [Hash] Optional query parameters
+      # @return [Hash] The API response as an IndifferentHash
+      def get(path, params = {})
+        @client.send(:request, :get, path, params)
+      end
+    end
+  end
+end

--- a/lib/jikanrb/resources/character_resource.rb
+++ b/lib/jikanrb/resources/character_resource.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Jikanrb
+  module Resources
+    # Resource class for accessing Character sub-resources from the Jikan API.
+    # Provides fluent API access to character details, anime appearances,
+    # manga appearances, voice actors, and pictures.
+    #
+    # @example Basic usage
+    #   client = Jikanrb::Client.new
+    #   character = client.character(1)
+    #   character.info                  # GET /characters/1
+    #   character.info(full: true)      # GET /characters/1/full
+    #   character.anime                 # GET /characters/1/anime
+    #   character.voices                # GET /characters/1/voices
+    #
+    # @see https://docs.api.jikan.moe/#tag/characters
+    class CharacterResource < BaseResource
+      # Returns character details
+      #
+      # @param full [Boolean] If true, returns extended information including
+      #   anime appearances, manga appearances, and voice actors
+      # @return [Hash] Character data as IndifferentHash
+      #
+      # @example Get basic info
+      #   client.character(1).info
+      #   # => { data: { mal_id: 1, name: "Spike Spiegel", ... } }
+      #
+      # @example Get full info
+      #   client.character(1).info(full: true)
+      #   # => { data: { mal_id: 1, name: "...", anime: [...], voices: [...] } }
+      def info(full: false)
+        path = full ? "characters/#{@id}/full" : "characters/#{@id}"
+        get(path)
+      end
+
+      # Returns anime appearances for this character
+      #
+      # @return [Hash] List of anime appearances as IndifferentHash
+      #
+      # @example
+      #   client.character(1).anime
+      #   # => { data: [{ role: "Main", anime: { mal_id: 1, title: "..." } }, ...] }
+      def animes
+        get("characters/#{@id}/anime")
+      end
+
+      # Returns manga appearances for this character
+      #
+      # @return [Hash] List of manga appearances as IndifferentHash
+      #
+      # @example
+      #   client.character(1).manga
+      #   # => { data: [{ role: "Main", manga: { mal_id: 1, title: "..." } }, ...] }
+      def mangas
+        get("characters/#{@id}/manga")
+      end
+
+      # Returns voice actors for this character
+      #
+      # @return [Hash] List of voice actors as IndifferentHash
+      #
+      # @example
+      #   client.character(1).voices
+      #   # => { data: [{ language: "Japanese", person: { mal_id: 11, name: "..." } }, ...] }
+      def voices
+        get("characters/#{@id}/voices")
+      end
+
+      # Returns pictures of this character
+      #
+      # @return [Hash] List of pictures as IndifferentHash
+      #
+      # @example
+      #   client.character(1).pictures
+      #   # => { data: [{ jpg: { image_url: "https://..." } }, ...] }
+      def pictures
+        get("characters/#{@id}/pictures")
+      end
+    end
+  end
+end

--- a/lib/jikanrb/resources/manga_resource.rb
+++ b/lib/jikanrb/resources/manga_resource.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Jikanrb
+  module Resources
+    # Resource class for accessing Manga sub-resources from the Jikan API.
+    # Provides fluent API access to manga details, characters, news,
+    # forum topics, pictures, statistics, and more.
+    #
+    # @example Basic usage
+    #   client = Jikanrb::Client.new
+    #   manga = client.manga(1)
+    #   manga.info                   # GET /manga/1
+    #   manga.info(full: true)       # GET /manga/1/full
+    #   manga.characters             # GET /manga/1/characters
+    #
+    # @see https://docs.api.jikan.moe/#tag/manga
+    class MangaResource < BaseResource
+      # Returns manga details
+      #
+      # @param full [Boolean] If true, returns extended information including
+      #   relations, external links, etc.
+      # @return [Hash] Manga data as IndifferentHash
+      #
+      # @example Get basic info
+      #   client.manga(1).info
+      #   # => { data: { mal_id: 1, title: "Monster", ... } }
+      #
+      # @example Get full info
+      #   client.manga(1).info(full: true)
+      #   # => { data: { mal_id: 1, title: "...", relations: [...], external: [...] } }
+      def info(full: false)
+        path = full ? "manga/#{@id}/full" : "manga/#{@id}"
+        get(path)
+      end
+
+      # Returns characters for this manga
+      #
+      # @return [Hash] List of characters as IndifferentHash
+      #
+      # @example
+      #   client.manga(1).characters
+      #   # => { data: [{ character: { mal_id: 1, name: "Kenzou Tenma" }, role: "Main" }, ...] }
+      def characters
+        get("manga/#{@id}/characters")
+      end
+
+      # Returns news articles related to this manga
+      #
+      # @return [Hash] List of news articles as IndifferentHash
+      #
+      # @example
+      #   client.manga(1).news
+      #   # => { data: [{ mal_id: 1, title: "...", date: "...", author_username: "..." }, ...] }
+      def news
+        get("manga/#{@id}/news")
+      end
+
+      # Returns forum topics related to this manga
+      #
+      # @return [Hash] List of forum topics as IndifferentHash
+      #
+      # @example
+      #   client.manga(1).forum
+      #   # => { data: [{ mal_id: 1, title: "...", date: "...", author_username: "..." }, ...] }
+      def forum
+        get("manga/#{@id}/forum")
+      end
+
+      # Returns pictures of this manga
+      #
+      # @return [Hash] List of pictures as IndifferentHash
+      #
+      # @example
+      #   client.manga(1).pictures
+      #   # => { data: [{ jpg: { image_url: "https://..." }, webp: { ... } }, ...] }
+      def pictures
+        get("manga/#{@id}/pictures")
+      end
+
+      # Returns statistics for this manga
+      #
+      # @return [Hash] Statistics data as IndifferentHash
+      #
+      # @example
+      #   client.manga(1).statistics
+      #   # => { data: { reading: 12345, completed: 67890, on_hold: 1234, ... } }
+      def statistics
+        get("manga/#{@id}/statistics")
+      end
+
+      # Returns user recommendations for this manga
+      #
+      # @return [Hash] List of recommendations as IndifferentHash
+      #
+      # @example
+      #   client.manga(1).recommendations
+      #   # => { data: [{ entry: { mal_id: 5, title: "..." }, votes: 123 }, ...] }
+      def recommendations
+        get("manga/#{@id}/recommendations")
+      end
+
+      # Returns related anime/manga entries
+      #
+      # @return [Hash] List of relations as IndifferentHash
+      #
+      # @example
+      #   client.manga(1).relations
+      #   # => { data: [{ relation: "Adaptation", entry: [{ mal_id: 19, type: "anime", name: "..." }] }, ...] }
+      def relations
+        get("manga/#{@id}/relations")
+      end
+
+      # Returns external links for this manga
+      #
+      # @return [Hash] List of external links as IndifferentHash
+      #
+      # @example
+      #   client.manga(1).external
+      #   # => { data: [{ name: "Official Site", url: "https://..." }, ...] }
+      def external
+        get("manga/#{@id}/external")
+      end
+    end
+  end
+end

--- a/lib/jikanrb/resources/person_resource.rb
+++ b/lib/jikanrb/resources/person_resource.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Jikanrb
+  module Resources
+    # Resource class for accessing Person sub-resources from the Jikan API.
+    # Provides fluent API access to person details, anime staff positions,
+    # manga work, voice acting roles, and pictures.
+    #
+    # @example Basic usage
+    #   client = Jikanrb::Client.new
+    #   person = client.person(1)
+    #   person.info                  # GET /people/1
+    #   person.info(full: true)      # GET /people/1/full
+    #   person.animes                # GET /people/1/anime
+    #   person.voices                # GET /people/1/voices
+    #
+    # @see https://docs.api.jikan.moe/#tag/people
+    class PersonResource < BaseResource
+      # Returns person details
+      #
+      # @param full [Boolean] If true, returns extended information including
+      #   anime, manga, and voice acting roles
+      # @return [Hash] Person data as IndifferentHash
+      #
+      # @example Get basic info
+      #   client.person(1).info
+      #   # => { data: { mal_id: 1, name: "Tomokazu Seki", ... } }
+      #
+      # @example Get full info
+      #   client.person(1).info(full: true)
+      #   # => { data: { mal_id: 1, name: "...", anime: [...], voices: [...] } }
+      def info(full: false)
+        path = full ? "people/#{@id}/full" : "people/#{@id}"
+        get(path)
+      end
+
+      # Returns anime staff positions for this person
+      #
+      # @return [Hash] List of anime staff positions as IndifferentHash
+      #
+      # @example
+      #   client.person(1).animes
+      #   # => { data: [{ position: "Director", anime: { mal_id: 1, title: "..." } }, ...] }
+      def animes
+        get("people/#{@id}/anime")
+      end
+
+      # Returns manga work positions for this person
+      #
+      # @return [Hash] List of manga work positions as IndifferentHash
+      #
+      # @example
+      #   client.person(1).mangas
+      #   # => { data: [{ position: "Story & Art", manga: { mal_id: 1, title: "..." } }, ...] }
+      def mangas
+        get("people/#{@id}/manga")
+      end
+
+      # Returns voice acting roles for this person
+      #
+      # @return [Hash] List of voice acting roles as IndifferentHash
+      #
+      # @example
+      #   client.person(1).voices
+      #   # => { data: [{ role: "Main", character: { ... }, anime: { ... } }, ...] }
+      def voices
+        get("people/#{@id}/voices")
+      end
+
+      # Returns pictures of this person
+      #
+      # @return [Hash] List of pictures as IndifferentHash
+      #
+      # @example
+      #   client.person(1).pictures
+      #   # => { data: [{ jpg: { image_url: "https://..." } }, ...] }
+      def pictures
+        get("people/#{@id}/pictures")
+      end
+    end
+  end
+end

--- a/lib/jikanrb/version.rb
+++ b/lib/jikanrb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Jikanrb
-  VERSION = '0.2.2'
+  VERSION = '0.3.0'
 end

--- a/spec/jikanrb/client_spec.rb
+++ b/spec/jikanrb/client_spec.rb
@@ -108,83 +108,30 @@ RSpec.describe Jikanrb::Client do
   end
 
   describe '#character' do
-    it 'fetches character by ID' do
-      response_body = {
-        data: {
-          mal_id: 1,
-          name: 'Spike Spiegel'
-        }
-      }.to_json
-
-      stub_request(:get, "#{base_url}/characters/1")
-        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
-
+    it 'returns a CharacterResource instance' do
       result = client.character(1)
 
-      expect(result).to be_a(Hash)
-      expect(result['data']).to be_a(Hash)
-      expect(result[:data]).to be_a(Hash)
-      expect(result['data']).to include('mal_id' => 1, 'name' => 'Spike Spiegel')
-      expect(result[:data]).to include(mal_id: 1, name: 'Spike Spiegel')
+      expect(result).to be_a(Jikanrb::Resources::CharacterResource)
     end
 
-    it 'fetches full character information' do
-      response_body = {
-        data: {
-          mal_id: 1,
-          name: 'Spike Spiegel'
-        }
-      }.to_json
+    it 'passes the correct ID to the resource' do
+      result = client.character(123)
 
-      stub_request(:get, "#{base_url}/characters/1/full")
-        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
-
-      result = client.character(1, full: true)
-
-      expect(result).to be_a(Hash)
-      expect(result[:data]).to be_a(Hash)
-      expect(result['data']).to be_a(Hash)
-      expect(result['data']['mal_id']).to eq(1)
+      expect(result.id).to eq(123)
     end
   end
 
   describe '#person' do
-    it 'fetches person by ID' do
-      response_body = {
-        data: {
-          mal_id: 1,
-          name: 'Rie Kugimiya'
-        }
-      }.to_json
-
-      stub_request(:get, "#{base_url}/people/1")
-        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
-
+    it 'returns a PersonResource instance' do
       result = client.person(1)
 
-      expect(result).to be_a(Hash)
-      expect(result[:data]).to be_a(Hash)
-      expect(result['data']).to be_a(Hash)
-      expect(result['data']['mal_id']).to eq(1)
+      expect(result).to be_a(Jikanrb::Resources::PersonResource)
     end
 
-    it 'fetches full person information' do
-      response_body = {
-        data: {
-          mal_id: 1,
-          name: 'Rie Kugimiya'
-        }
-      }.to_json
+    it 'passes the correct ID to the resource' do
+      result = client.person(456)
 
-      stub_request(:get, "#{base_url}/people/1/full")
-        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
-
-      result = client.person(1, full: true)
-
-      expect(result).to be_a(Hash)
-      expect(result[:data]).to be_a(Hash)
-      expect(result['data']).to be_a(Hash)
-      expect(result['data']['mal_id']).to eq(1)
+      expect(result.id).to eq(456)
     end
   end
 

--- a/spec/jikanrb/client_spec.rb
+++ b/spec/jikanrb/client_spec.rb
@@ -22,7 +22,19 @@ RSpec.describe Jikanrb::Client do
   end
 
   describe '#anime' do
-    it 'fetches anime by ID' do
+    it 'returns an AnimeResource instance' do
+      result = client.anime(1)
+
+      expect(result).to be_a(Jikanrb::Resources::AnimeResource)
+    end
+
+    it 'passes the correct ID to the resource' do
+      result = client.anime(123)
+
+      expect(result.id).to eq(123)
+    end
+
+    it 'fetches anime info via fluent API' do
       response_body = {
         data: {
           mal_id: 1,
@@ -34,7 +46,7 @@ RSpec.describe Jikanrb::Client do
       stub_request(:get, "#{base_url}/anime/1")
         .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
 
-      result = client.anime(1)
+      result = client.anime(1).info
 
       expect(result[:data]).to be_a(Hash)
       expect(result['data']).to be_a(Hash)
@@ -42,7 +54,7 @@ RSpec.describe Jikanrb::Client do
       expect(result['data']).to include('mal_id' => 1, 'title' => 'Cowboy Bebop')
     end
 
-    it 'fetches full anime information' do
+    it 'fetches full anime information via fluent API' do
       response_body = {
         data: {
           mal_id: 1,
@@ -54,7 +66,7 @@ RSpec.describe Jikanrb::Client do
       stub_request(:get, "#{base_url}/anime/1/full")
         .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
 
-      result = client.anime(1, full: true)
+      result = client.anime(1).info(full: true)
 
       expect(result).to be_a(Hash)
       expect(result[:data]).to be_a(Hash)
@@ -65,7 +77,19 @@ RSpec.describe Jikanrb::Client do
   end
 
   describe '#manga' do
-    it 'fetches manga by ID' do
+    it 'returns a MangaResource instance' do
+      result = client.manga(1)
+
+      expect(result).to be_a(Jikanrb::Resources::MangaResource)
+    end
+
+    it 'passes the correct ID to the resource' do
+      result = client.manga(123)
+
+      expect(result.id).to eq(123)
+    end
+
+    it 'fetches manga info via fluent API' do
       response_body = {
         data: {
           mal_id: 1,
@@ -77,7 +101,7 @@ RSpec.describe Jikanrb::Client do
       stub_request(:get, "#{base_url}/manga/1")
         .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
 
-      result = client.manga(1)
+      result = client.manga(1).info
 
       expect(result).to be_a(Hash)
       expect(result[:data]).to be_a(Hash)
@@ -86,7 +110,7 @@ RSpec.describe Jikanrb::Client do
       expect(result[:data]).to include(mal_id: 1, title: 'Monster')
     end
 
-    it 'fetches full manga information' do
+    it 'fetches full manga information via fluent API' do
       response_body = {
         data: {
           mal_id: 1,
@@ -97,7 +121,7 @@ RSpec.describe Jikanrb::Client do
       stub_request(:get, "#{base_url}/manga/1/full")
         .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
 
-      result = client.manga(1, full: true)
+      result = client.manga(1).info(full: true)
 
       expect(result).to be_a(Hash)
       expect(result[:data]).to be_a(Hash)
@@ -336,7 +360,7 @@ RSpec.describe Jikanrb::Client do
           .to_return(status: 404, body: '', headers: {})
 
         expect do
-          client.anime(999_999_999)
+          client.anime(999_999_999).info
         end.to raise_error(Jikanrb::NotFoundError, /not found/)
       end
     end
@@ -358,7 +382,7 @@ RSpec.describe Jikanrb::Client do
         allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(error)
 
         expect do
-          client.anime(1)
+          client.anime(1).info
         end.to raise_error(Jikanrb::ConnectionError, /Connection failed/)
       end
     end
@@ -368,7 +392,7 @@ RSpec.describe Jikanrb::Client do
         allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::TimeoutError.new('Timeout'))
 
         expect do
-          client.anime(1)
+          client.anime(1).info
         end.to raise_error(Jikanrb::ConnectionError, /Connection failed/)
       end
     end
@@ -379,7 +403,7 @@ RSpec.describe Jikanrb::Client do
           .to_return(status: 200, body: 'invalid json{', headers: {})
 
         expect do
-          client.anime(1)
+          client.anime(1).info
         end.to raise_error(Jikanrb::ParseError, /Failed to parse JSON/)
       end
     end

--- a/spec/jikanrb/resources/anime_resource_spec.rb
+++ b/spec/jikanrb/resources/anime_resource_spec.rb
@@ -1,0 +1,598 @@
+# frozen_string_literal: true
+
+RSpec.describe Jikanrb::Resources::AnimeResource do
+  subject(:resource) { described_class.new(client, anime_id) }
+
+  let(:client) { Jikanrb::Client.new }
+  let(:anime_id) { 1 }
+  let(:base_url) { 'https://api.jikan.moe/v4' }
+
+  describe '#initialize' do
+    it 'stores the client reference' do
+      expect(resource.instance_variable_get(:@client)).to eq(client)
+    end
+
+    it 'stores the anime ID' do
+      expect(resource.instance_variable_get(:@id)).to eq(anime_id)
+    end
+  end
+
+  describe '#info' do
+    context 'when fetching basic info' do
+      let(:response_body) do
+        {
+          data: {
+            mal_id: 1,
+            title: 'Cowboy Bebop',
+            title_japanese: 'カウボーイビバップ',
+            episodes: 26
+          }
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "#{base_url}/anime/#{anime_id}")
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns anime details as hash' do
+        expect(resource.info).to be_a(Hash)
+      end
+
+      it 'returns correct mal_id with symbol access' do
+        expect(resource.info[:data][:mal_id]).to eq(1)
+      end
+
+      it 'returns correct title with string access' do
+        expect(resource.info['data']['title']).to eq('Cowboy Bebop')
+      end
+    end
+
+    context 'when fetching full info' do
+      let(:response_body) do
+        {
+          data: {
+            mal_id: 1,
+            title: 'Cowboy Bebop',
+            relations: [],
+            theme: { openings: [], endings: [] },
+            external: [],
+            streaming: []
+          }
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "#{base_url}/anime/#{anime_id}/full")
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns extended anime details' do
+        result = resource.info(full: true)
+
+        expect(result[:data][:mal_id]).to eq(1)
+        expect(result[:data][:relations]).to be_a(Array)
+        expect(result[:data][:external]).to be_a(Array)
+      end
+    end
+  end
+
+  describe '#characters' do
+    let(:response_body) do
+      {
+        data: [
+          { character: { mal_id: 1, name: 'Spike Spiegel' }, role: 'Main' },
+          { character: { mal_id: 2, name: 'Faye Valentine' }, role: 'Main' }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/characters")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns anime characters as array' do
+      result = resource.characters
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:role]).to eq('Main')
+    end
+
+    it 'supports string access for character data' do
+      expect(resource.characters['data'].first['character']['name']).to eq('Spike Spiegel')
+    end
+  end
+
+  describe '#staff' do
+    let(:response_body) do
+      {
+        data: [
+          { person: { mal_id: 40_135, name: 'Shinichiro Watanabe' }, positions: ['Director'] },
+          { person: { mal_id: 508, name: 'Yoko Kanno' }, positions: ['Music'] }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/staff")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns anime staff as array' do
+      result = resource.staff
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:positions]).to include('Director')
+    end
+
+    it 'supports string access for staff data' do
+      expect(resource.staff['data'].first['person']['name']).to eq('Shinichiro Watanabe')
+    end
+  end
+
+  describe '#episodes' do
+    let(:response_body) do
+      {
+        data: [
+          { mal_id: 1, title: 'Asteroid Blues', aired: '1998-10-24' },
+          { mal_id: 2, title: 'Stray Dog Strut', aired: '1998-04-03' }
+        ],
+        pagination: { last_visible_page: 2, has_next_page: true }
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/episodes")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns anime episodes as array' do
+      result = resource.episodes
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].first[:title]).to eq('Asteroid Blues')
+    end
+
+    it 'includes pagination information' do
+      result = resource.episodes
+
+      expect(result[:pagination][:has_next_page]).to be(true)
+    end
+
+    context 'with page parameter' do
+      before do
+        stub_request(:get, "#{base_url}/anime/#{anime_id}/episodes")
+          .with(query: { page: 2 })
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'passes page parameter to API' do
+        resource.episodes(page: 2)
+
+        expect(WebMock).to have_requested(:get, "#{base_url}/anime/#{anime_id}/episodes")
+          .with(query: { page: 2 })
+      end
+    end
+  end
+
+  describe '#news' do
+    let(:response_body) do
+      {
+        data: [
+          { mal_id: 12_345, title: 'Cowboy Bebop Anniversary', date: '2023-04-03' }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/news")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns anime news as array' do
+      result = resource.news
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].first[:title]).to eq('Cowboy Bebop Anniversary')
+    end
+  end
+
+  describe '#forum' do
+    let(:response_body) do
+      {
+        data: [
+          { mal_id: 1234, title: 'Best episodes discussion', comments: 42 }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/forum")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns anime forum topics as array' do
+      result = resource.forum
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].first[:title]).to eq('Best episodes discussion')
+    end
+  end
+
+  describe '#videos' do
+    let(:response_body) do
+      {
+        data: {
+          promo: [{ title: 'PV 1', trailer: { youtube_id: 'abc123' } }],
+          episodes: [{ mal_id: 1, title: 'Episode 1', episode: '1' }]
+        }
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/videos")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns anime videos' do
+      result = resource.videos
+
+      expect(result[:data][:promo]).to be_a(Array)
+      expect(result[:data][:promo].first[:title]).to eq('PV 1')
+    end
+
+    it 'includes episodes videos' do
+      result = resource.videos
+
+      expect(result[:data][:episodes]).to be_a(Array)
+    end
+  end
+
+  describe '#pictures' do
+    let(:response_body) do
+      {
+        data: [
+          { jpg: { image_url: 'https://cdn.myanimelist.net/images/anime/4/19644.jpg' } },
+          { jpg: { image_url: 'https://cdn.myanimelist.net/images/anime/4/19645.jpg' } }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/pictures")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns anime pictures' do
+      result = resource.pictures
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:jpg][:image_url]).to include('myanimelist.net')
+    end
+  end
+
+  describe '#statistics' do
+    let(:response_body) do
+      {
+        data: {
+          watching: 150_000,
+          completed: 800_000,
+          on_hold: 50_000,
+          dropped: 20_000,
+          plan_to_watch: 200_000,
+          total: 1_220_000,
+          scores: [{ score: 10, votes: 100_000, percentage: 30.5 }]
+        }
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/statistics")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns anime statistics' do
+      result = resource.statistics
+
+      expect(result[:data][:watching]).to eq(150_000)
+      expect(result[:data][:completed]).to eq(800_000)
+      expect(result[:data][:total]).to eq(1_220_000)
+    end
+
+    it 'includes score distribution' do
+      result = resource.statistics
+
+      expect(result[:data][:scores]).to be_a(Array)
+      expect(result[:data][:scores].first[:score]).to eq(10)
+    end
+  end
+
+  describe '#recommendations' do
+    let(:response_body) do
+      {
+        data: [
+          { entry: { mal_id: 5, title: 'Cowboy Bebop: Tengoku no Tobira' }, votes: 100 },
+          { entry: { mal_id: 205, title: 'Samurai Champloo' }, votes: 85 }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/recommendations")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns anime recommendations as array' do
+      result = resource.recommendations
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:votes]).to eq(100)
+    end
+
+    it 'includes recommended entry details' do
+      result = resource.recommendations
+
+      expect(result[:data].first[:entry][:title]).to eq('Cowboy Bebop: Tengoku no Tobira')
+    end
+  end
+
+  describe '#relations' do
+    let(:response_body) do
+      {
+        data: [
+          { relation: 'Sequel', entry: [{ mal_id: 5, name: 'Cowboy Bebop: Tengoku no Tobira' }] },
+          { relation: 'Side story', entry: [{ mal_id: 17_205, name: 'Cowboy Bebop: Ein no Natsuyasumi' }] }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/relations")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns anime relations as array' do
+      result = resource.relations
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].first[:relation]).to eq('Sequel')
+    end
+
+    it 'includes related entries' do
+      result = resource.relations
+
+      expect(result[:data].first[:entry]).to be_a(Array)
+      expect(result[:data].first[:entry].first[:name]).to eq('Cowboy Bebop: Tengoku no Tobira')
+    end
+  end
+
+  describe '#themes' do
+    let(:response_body) do
+      {
+        data: {
+          openings: ['Tank! by Seatbelts'],
+          endings: ['The Real Folk Blues by Seatbelts']
+        }
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/themes")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns anime themes' do
+      result = resource.themes
+
+      expect(result[:data][:openings]).to be_a(Array)
+      expect(result[:data][:openings].first).to include('Tank!')
+    end
+
+    it 'includes both openings and endings' do
+      result = resource.themes
+
+      expect(result[:data][:endings]).to be_a(Array)
+      expect(result[:data][:endings].first).to include('Real Folk Blues')
+    end
+  end
+
+  describe '#external' do
+    let(:response_body) do
+      {
+        data: [
+          { name: 'Official Site', url: 'http://www.cowboy-bebop.net/' },
+          { name: 'Wikipedia', url: 'https://en.wikipedia.org/wiki/Cowboy_Bebop' }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/external")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns external links as array' do
+      result = resource.external
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:name]).to eq('Official Site')
+    end
+  end
+
+  describe '#streaming' do
+    let(:response_body) do
+      {
+        data: [
+          { name: 'Crunchyroll', url: 'https://www.crunchyroll.com/cowboy-bebop' },
+          { name: 'Funimation', url: 'https://www.funimation.com/shows/cowboy-bebop/' }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/anime/#{anime_id}/streaming")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns streaming links as array' do
+      result = resource.streaming
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:name]).to eq('Crunchyroll')
+    end
+  end
+
+  describe 'Client#anime fluent API integration' do
+    describe '#anime' do
+      it 'returns an AnimeResource instance' do
+        expect(client.anime(1)).to be_a(described_class)
+      end
+
+      it 'passes the correct ID to the resource' do
+        expect(client.anime(123).instance_variable_get(:@id)).to eq(123)
+      end
+
+      it 'passes the client reference to the resource' do
+        expect(client.anime(1).instance_variable_get(:@client)).to eq(client)
+      end
+    end
+
+    describe 'fluent chaining' do
+      it 'allows chaining .anime(id).info' do
+        stub_request(:get, "#{base_url}/anime/1")
+          .to_return(status: 200, body: { data: { mal_id: 1, title: 'Cowboy Bebop' } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).info[:data][:title]).to eq('Cowboy Bebop')
+      end
+
+      it 'allows chaining .anime(id).info(full: true)' do
+        stub_request(:get, "#{base_url}/anime/1/full")
+          .to_return(status: 200, body: { data: { mal_id: 1, title: 'Cowboy Bebop', relations: [] } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).info(full: true)[:data][:relations]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).characters' do
+        stub_request(:get, "#{base_url}/anime/1/characters")
+          .to_return(status: 200, body: { data: [{ role: 'Main', character: { mal_id: 1 } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).characters[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).staff' do
+        stub_request(:get, "#{base_url}/anime/1/staff")
+          .to_return(status: 200, body: { data: [{ positions: ['Director'], person: { mal_id: 1 } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).staff[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).episodes' do
+        stub_request(:get, "#{base_url}/anime/1/episodes")
+          .to_return(status: 200, body: { data: [{ mal_id: 1, title: 'Episode 1' }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).episodes[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).episodes(page: 2)' do
+        stub_request(:get, "#{base_url}/anime/1/episodes")
+          .with(query: { page: 2 })
+          .to_return(status: 200, body: { data: [{ mal_id: 26, title: 'Episode 26' }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).episodes(page: 2)[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).news' do
+        stub_request(:get, "#{base_url}/anime/1/news")
+          .to_return(status: 200, body: { data: [{ title: 'News title' }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).news[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).forum' do
+        stub_request(:get, "#{base_url}/anime/1/forum")
+          .to_return(status: 200, body: { data: [{ title: 'Forum topic' }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).forum[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).videos' do
+        stub_request(:get, "#{base_url}/anime/1/videos")
+          .to_return(status: 200, body: { data: { promo: [], episodes: [] } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).videos[:data][:promo]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).pictures' do
+        stub_request(:get, "#{base_url}/anime/1/pictures")
+          .to_return(status: 200, body: { data: [{ jpg: { image_url: 'https://example.com/pic.jpg' } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).pictures[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).statistics' do
+        stub_request(:get, "#{base_url}/anime/1/statistics")
+          .to_return(status: 200, body: { data: { watching: 1000, completed: 5000 } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).statistics[:data][:watching]).to eq(1000)
+      end
+
+      it 'allows chaining .anime(id).recommendations' do
+        stub_request(:get, "#{base_url}/anime/1/recommendations")
+          .to_return(status: 200, body: { data: [{ entry: { mal_id: 5 }, votes: 10 }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).recommendations[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).relations' do
+        stub_request(:get, "#{base_url}/anime/1/relations")
+          .to_return(status: 200, body: { data: [{ relation: 'Sequel', entry: [] }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).relations[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).themes' do
+        stub_request(:get, "#{base_url}/anime/1/themes")
+          .to_return(status: 200, body: { data: { openings: ['OP1'], endings: ['ED1'] } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).themes[:data][:openings]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).external' do
+        stub_request(:get, "#{base_url}/anime/1/external")
+          .to_return(status: 200, body: { data: [{ name: 'Site', url: 'https://example.com' }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).external[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .anime(id).streaming' do
+        stub_request(:get, "#{base_url}/anime/1/streaming")
+          .to_return(status: 200, body: { data: [{ name: 'Crunchyroll', url: 'https://crunchyroll.com' }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.anime(1).streaming[:data]).to be_a(Array)
+      end
+    end
+  end
+end

--- a/spec/jikanrb/resources/base_resource_spec.rb
+++ b/spec/jikanrb/resources/base_resource_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+RSpec.describe Jikanrb::Resources::BaseResource do
+  subject(:resource) { described_class.new(client, resource_id) }
+
+  let(:client) { Jikanrb::Client.new }
+  let(:resource_id) { 1 }
+  let(:base_url) { 'https://api.jikan.moe/v4' }
+
+  describe '#initialize' do
+    it 'stores the client reference' do
+      expect(resource.instance_variable_get(:@client)).to eq(client)
+    end
+
+    it 'stores the resource id' do
+      expect(resource.id).to eq(resource_id)
+    end
+  end
+
+  describe '#id' do
+    it 'returns the resource ID' do
+      expect(resource.id).to eq(1)
+    end
+
+    it 'is read-only' do
+      expect(resource).not_to respond_to(:id=)
+    end
+  end
+
+  describe '#get (private)' do
+    it 'delegates GET requests to the client' do
+      response_body = { data: { mal_id: 1, name: 'Test' } }.to_json
+
+      stub_request(:get, "#{base_url}/test/1")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+
+      result = resource.send(:get, 'test/1')
+
+      expect(result).to be_a(Hash)
+      expect(result[:data][:mal_id]).to eq(1)
+    end
+
+    it 'passes query parameters to the client' do
+      response_body = { data: [], pagination: { current_page: 2 } }.to_json
+
+      stub_request(:get, "#{base_url}/test/1/items")
+        .with(query: { page: 2 })
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+
+      result = resource.send(:get, 'test/1/items', page: 2)
+
+      expect(result[:pagination][:current_page]).to eq(2)
+    end
+
+    it 'returns IndifferentHash for flexible key access' do
+      response_body = { data: { mal_id: 1, title: 'Test' } }.to_json
+
+      stub_request(:get, "#{base_url}/test/1")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+
+      result = resource.send(:get, 'test/1')
+
+      expect(result[:data][:title]).to eq('Test')
+      expect(result['data']['title']).to eq('Test')
+    end
+
+    it 'propagates client errors' do
+      stub_request(:get, "#{base_url}/test/999")
+        .to_return(status: 404, body: { error: 'Not found' }.to_json)
+
+      expect { resource.send(:get, 'test/999') }.to raise_error(Jikanrb::NotFoundError)
+    end
+  end
+
+  describe 'subclass usage' do
+    let(:test_resource_class) do
+      Class.new(described_class) do
+        def info
+          get("people/#{@id}")
+        end
+
+        def anime
+          get("people/#{@id}/anime")
+        end
+      end
+    end
+
+    let(:test_resource) { test_resource_class.new(client, 1) }
+
+    it 'allows subclasses to define resource methods' do
+      response_body = { data: { mal_id: 1, name: 'Test Person' } }.to_json
+
+      stub_request(:get, "#{base_url}/people/1")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+
+      result = test_resource.info
+
+      expect(result[:data][:name]).to eq('Test Person')
+    end
+
+    it 'allows subclasses to access sub-resources' do
+      response_body = { data: [{ position: 'Director', anime: { title: 'Test Anime' } }] }.to_json
+
+      stub_request(:get, "#{base_url}/people/1/anime")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+
+      result = test_resource.anime
+
+      expect(result[:data]).to be_an(Array)
+      expect(result[:data].first[:position]).to eq('Director')
+    end
+  end
+end

--- a/spec/jikanrb/resources/character_resource_spec.rb
+++ b/spec/jikanrb/resources/character_resource_spec.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+RSpec.describe Jikanrb::Resources::CharacterResource do
+  subject(:resource) { described_class.new(client, character_id) }
+
+  let(:client) { Jikanrb::Client.new }
+  let(:character_id) { 1 }
+  let(:base_url) { 'https://api.jikan.moe/v4' }
+
+  describe '#initialize' do
+    it 'stores the client reference' do
+      expect(resource.instance_variable_get(:@client)).to eq(client)
+    end
+
+    it 'stores the character ID' do
+      expect(resource.instance_variable_get(:@id)).to eq(character_id)
+    end
+  end
+
+  describe '#info' do
+    context 'when fetching basic info' do
+      let(:response_body) do
+        {
+          data: {
+            mal_id: 1,
+            name: 'Spike Spiegel',
+            name_kanji: 'スパイク・スピーゲル',
+            nicknames: ['Spike']
+          }
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "#{base_url}/characters/#{character_id}")
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns character details as hash' do
+        expect(resource.info).to be_a(Hash)
+      end
+
+      it 'returns correct mal_id with symbol access' do
+        expect(resource.info[:data][:mal_id]).to eq(1)
+      end
+
+      it 'returns correct name_kanji with string access' do
+        expect(resource.info['data']['name_kanji']).to eq('スパイク・スピーゲル')
+      end
+    end
+
+    context 'when fetching full info' do
+      let(:response_body) do
+        {
+          data: {
+            mal_id: 1,
+            name: 'Spike Spiegel',
+            anime: [],
+            manga: [],
+            voices: []
+          }
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "#{base_url}/characters/#{character_id}/full")
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns extended character details' do
+        result = resource.info(full: true)
+
+        expect(result[:data][:mal_id]).to eq(1)
+        expect(result[:data][:anime]).to be_a(Array)
+        expect(result[:data][:manga]).to be_a(Array)
+        expect(result[:data][:voices]).to be_a(Array)
+      end
+    end
+  end
+
+  describe '#animes' do
+    let(:response_body) do
+      {
+        data: [
+          { role: 'Main', anime: { mal_id: 1, title: 'Cowboy Bebop' } },
+          { role: 'Main', anime: { mal_id: 5, title: 'Cowboy Bebop: Tengoku no Tobira' } }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/characters/#{character_id}/anime")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it "returns character's anime appearances as array" do
+      result = resource.animes
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:role]).to eq('Main')
+    end
+
+    it 'supports string access for anime data' do
+      expect(resource.animes['data'].first['anime']['title']).to eq('Cowboy Bebop')
+    end
+  end
+
+  describe '#mangas' do
+    let(:response_body) do
+      {
+        data: [
+          { role: 'Main', manga: { mal_id: 173, title: 'Cowboy Bebop' } }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/characters/#{character_id}/manga")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it "returns character's manga appearances" do
+      result = resource.mangas
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].first[:role]).to eq('Main')
+    end
+
+    it 'supports string access for manga data' do
+      expect(resource.mangas['data'].first['manga']['title']).to eq('Cowboy Bebop')
+    end
+  end
+
+  describe '#voices' do
+    let(:response_body) do
+      {
+        data: [
+          { language: 'Japanese', person: { mal_id: 11, name: 'Koichi Yamadera' } },
+          { language: 'English', person: { mal_id: 468, name: 'Steve Blum' } }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/characters/#{character_id}/voices")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it "returns character's voice actors" do
+      result = resource.voices
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:language]).to eq('Japanese')
+    end
+
+    it 'includes voice actor person information' do
+      result = resource.voices
+
+      expect(result[:data].first[:person][:name]).to eq('Koichi Yamadera')
+      expect(result['data'].last['person']['name']).to eq('Steve Blum')
+    end
+  end
+
+  describe '#pictures' do
+    let(:response_body) do
+      {
+        data: [
+          { jpg: { image_url: 'https://cdn.myanimelist.net/images/characters/4/50197.jpg' } },
+          { jpg: { image_url: 'https://cdn.myanimelist.net/images/characters/4/50198.jpg' } }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/characters/#{character_id}/pictures")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it "returns character's pictures" do
+      result = resource.pictures
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:jpg][:image_url]).to include('myanimelist.net')
+    end
+  end
+
+  describe 'Client#character fluent API integration' do
+    describe '#character' do
+      it 'returns a CharacterResource instance' do
+        expect(client.character(1)).to be_a(described_class)
+      end
+
+      it 'passes the correct ID to the resource' do
+        expect(client.character(123).instance_variable_get(:@id)).to eq(123)
+      end
+
+      it 'passes the client reference to the resource' do
+        expect(client.character(1).instance_variable_get(:@client)).to eq(client)
+      end
+    end
+
+    describe 'fluent chaining' do
+      it 'allows chaining .character(id).info' do
+        stub_request(:get, "#{base_url}/characters/1")
+          .to_return(status: 200, body: { data: { mal_id: 1, name: 'Spike Spiegel' } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.character(1).info[:data][:name]).to eq('Spike Spiegel')
+      end
+
+      it 'allows chaining .character(id).info(full: true)' do
+        stub_request(:get, "#{base_url}/characters/1/full")
+          .to_return(status: 200, body: { data: { mal_id: 1, name: 'Spike Spiegel', anime: [] } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.character(1).info(full: true)[:data][:anime]).to be_a(Array)
+      end
+
+      it 'allows chaining .character(id).animes' do
+        stub_request(:get, "#{base_url}/characters/1/anime")
+          .to_return(status: 200, body: { data: [{ role: 'Main', anime: { mal_id: 1 } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.character(1).animes[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .character(id).mangas' do
+        stub_request(:get, "#{base_url}/characters/1/manga")
+          .to_return(status: 200, body: { data: [{ role: 'Main', manga: { mal_id: 1 } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.character(1).mangas[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .character(id).voices' do
+        stub_request(:get, "#{base_url}/characters/1/voices")
+          .to_return(status: 200, body: { data: [{ language: 'Japanese', person: { mal_id: 1 } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.character(1).voices[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .character(id).pictures' do
+        stub_request(:get, "#{base_url}/characters/1/pictures")
+          .to_return(status: 200, body: { data: [{ jpg: { image_url: 'https://example.com/pic.jpg' } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.character(1).pictures[:data]).to be_a(Array)
+      end
+    end
+  end
+end

--- a/spec/jikanrb/resources/manga_resource_spec.rb
+++ b/spec/jikanrb/resources/manga_resource_spec.rb
@@ -1,0 +1,392 @@
+# frozen_string_literal: true
+
+RSpec.describe Jikanrb::Resources::MangaResource do
+  subject(:resource) { described_class.new(client, manga_id) }
+
+  let(:client) { Jikanrb::Client.new }
+  let(:manga_id) { 1 }
+  let(:base_url) { 'https://api.jikan.moe/v4' }
+
+  describe '#initialize' do
+    it 'stores the client reference' do
+      expect(resource.instance_variable_get(:@client)).to eq(client)
+    end
+
+    it 'stores the manga ID' do
+      expect(resource.instance_variable_get(:@id)).to eq(manga_id)
+    end
+  end
+
+  describe '#info' do
+    context 'when fetching basic info' do
+      let(:response_body) do
+        {
+          data: {
+            mal_id: 1,
+            title: 'Monster',
+            title_japanese: 'MONSTER',
+            chapters: 162,
+            volumes: 18
+          }
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "#{base_url}/manga/#{manga_id}")
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns manga details as hash' do
+        expect(resource.info).to be_a(Hash)
+      end
+
+      it 'returns correct mal_id with symbol access' do
+        expect(resource.info[:data][:mal_id]).to eq(1)
+      end
+
+      it 'returns correct title with string access' do
+        expect(resource.info['data']['title']).to eq('Monster')
+      end
+    end
+
+    context 'when fetching full info' do
+      let(:response_body) do
+        {
+          data: {
+            mal_id: 1,
+            title: 'Monster',
+            relations: [],
+            external: []
+          }
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "#{base_url}/manga/#{manga_id}/full")
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns extended manga details' do
+        result = resource.info(full: true)
+
+        expect(result[:data][:mal_id]).to eq(1)
+        expect(result[:data][:relations]).to be_a(Array)
+        expect(result[:data][:external]).to be_a(Array)
+      end
+    end
+  end
+
+  describe '#characters' do
+    let(:response_body) do
+      {
+        data: [
+          { character: { mal_id: 1, name: 'Kenzou Tenma' }, role: 'Main' },
+          { character: { mal_id: 2, name: 'Johan Liebert' }, role: 'Main' }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/manga/#{manga_id}/characters")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns manga characters as array' do
+      result = resource.characters
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:role]).to eq('Main')
+    end
+
+    it 'supports string access for character data' do
+      expect(resource.characters['data'].first['character']['name']).to eq('Kenzou Tenma')
+    end
+  end
+
+  describe '#news' do
+    let(:response_body) do
+      {
+        data: [
+          { mal_id: 12_345, title: 'Monster Live-Action Adaptation Announced', date: '2023-06-15' }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/manga/#{manga_id}/news")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns manga news as array' do
+      result = resource.news
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].first[:title]).to eq('Monster Live-Action Adaptation Announced')
+    end
+  end
+
+  describe '#forum' do
+    let(:response_body) do
+      {
+        data: [
+          { mal_id: 1234, title: 'Best manga ever discussion', comments: 156 }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/manga/#{manga_id}/forum")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns manga forum topics as array' do
+      result = resource.forum
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].first[:title]).to eq('Best manga ever discussion')
+    end
+  end
+
+  describe '#pictures' do
+    let(:response_body) do
+      {
+        data: [
+          { jpg: { image_url: 'https://cdn.myanimelist.net/images/manga/3/54525.jpg' } },
+          { jpg: { image_url: 'https://cdn.myanimelist.net/images/manga/3/54526.jpg' } }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/manga/#{manga_id}/pictures")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns manga pictures' do
+      result = resource.pictures
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:jpg][:image_url]).to include('myanimelist.net')
+    end
+  end
+
+  describe '#statistics' do
+    let(:response_body) do
+      {
+        data: {
+          reading: 50_000,
+          completed: 300_000,
+          on_hold: 25_000,
+          dropped: 10_000,
+          plan_to_read: 100_000,
+          total: 485_000,
+          scores: [{ score: 10, votes: 50_000, percentage: 25.5 }]
+        }
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/manga/#{manga_id}/statistics")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns manga statistics' do
+      result = resource.statistics
+
+      expect(result[:data][:reading]).to eq(50_000)
+      expect(result[:data][:completed]).to eq(300_000)
+      expect(result[:data][:total]).to eq(485_000)
+    end
+
+    it 'includes score distribution' do
+      result = resource.statistics
+
+      expect(result[:data][:scores]).to be_a(Array)
+      expect(result[:data][:scores].first[:score]).to eq(10)
+    end
+  end
+
+  describe '#recommendations' do
+    let(:response_body) do
+      {
+        data: [
+          { entry: { mal_id: 2, title: 'Berserk' }, votes: 150 },
+          { entry: { mal_id: 3, title: '20th Century Boys' }, votes: 120 }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/manga/#{manga_id}/recommendations")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns manga recommendations as array' do
+      result = resource.recommendations
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:votes]).to eq(150)
+    end
+
+    it 'includes recommended entry details' do
+      result = resource.recommendations
+
+      expect(result[:data].first[:entry][:title]).to eq('Berserk')
+    end
+  end
+
+  describe '#relations' do
+    let(:response_body) do
+      {
+        data: [
+          { relation: 'Adaptation', entry: [{ mal_id: 19, name: 'Monster' }] },
+          { relation: 'Side story', entry: [{ mal_id: 1094, name: 'Another Monster' }] }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/manga/#{manga_id}/relations")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns manga relations as array' do
+      result = resource.relations
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].first[:relation]).to eq('Adaptation')
+    end
+
+    it 'includes related entries' do
+      result = resource.relations
+
+      expect(result[:data].first[:entry]).to be_a(Array)
+      expect(result[:data].first[:entry].first[:name]).to eq('Monster')
+    end
+  end
+
+  describe '#external' do
+    let(:response_body) do
+      {
+        data: [
+          { name: 'Official Site', url: 'http://monster.viz.com/' },
+          { name: 'Wikipedia', url: 'https://en.wikipedia.org/wiki/Monster_(manga)' }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/manga/#{manga_id}/external")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns external links as array' do
+      result = resource.external
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:name]).to eq('Official Site')
+    end
+  end
+
+  describe 'Client#manga fluent API integration' do
+    describe '#manga' do
+      it 'returns a MangaResource instance' do
+        expect(client.manga(1)).to be_a(described_class)
+      end
+
+      it 'passes the correct ID to the resource' do
+        expect(client.manga(123).instance_variable_get(:@id)).to eq(123)
+      end
+
+      it 'passes the client reference to the resource' do
+        expect(client.manga(1).instance_variable_get(:@client)).to eq(client)
+      end
+    end
+
+    describe 'fluent chaining' do
+      it 'allows chaining .manga(id).info' do
+        stub_request(:get, "#{base_url}/manga/1")
+          .to_return(status: 200, body: { data: { mal_id: 1, title: 'Monster' } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.manga(1).info[:data][:title]).to eq('Monster')
+      end
+
+      it 'allows chaining .manga(id).info(full: true)' do
+        stub_request(:get, "#{base_url}/manga/1/full")
+          .to_return(status: 200, body: { data: { mal_id: 1, title: 'Monster', relations: [] } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.manga(1).info(full: true)[:data][:relations]).to be_a(Array)
+      end
+
+      it 'allows chaining .manga(id).characters' do
+        stub_request(:get, "#{base_url}/manga/1/characters")
+          .to_return(status: 200, body: { data: [{ role: 'Main', character: { mal_id: 1 } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.manga(1).characters[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .manga(id).news' do
+        stub_request(:get, "#{base_url}/manga/1/news")
+          .to_return(status: 200, body: { data: [{ title: 'News title' }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.manga(1).news[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .manga(id).forum' do
+        stub_request(:get, "#{base_url}/manga/1/forum")
+          .to_return(status: 200, body: { data: [{ title: 'Forum topic' }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.manga(1).forum[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .manga(id).pictures' do
+        stub_request(:get, "#{base_url}/manga/1/pictures")
+          .to_return(status: 200, body: { data: [{ jpg: { image_url: 'https://example.com/pic.jpg' } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.manga(1).pictures[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .manga(id).statistics' do
+        stub_request(:get, "#{base_url}/manga/1/statistics")
+          .to_return(status: 200, body: { data: { reading: 1000, completed: 5000 } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.manga(1).statistics[:data][:reading]).to eq(1000)
+      end
+
+      it 'allows chaining .manga(id).recommendations' do
+        stub_request(:get, "#{base_url}/manga/1/recommendations")
+          .to_return(status: 200, body: { data: [{ entry: { mal_id: 5 }, votes: 10 }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.manga(1).recommendations[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .manga(id).relations' do
+        stub_request(:get, "#{base_url}/manga/1/relations")
+          .to_return(status: 200, body: { data: [{ relation: 'Adaptation', entry: [] }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.manga(1).relations[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .manga(id).external' do
+        stub_request(:get, "#{base_url}/manga/1/external")
+          .to_return(status: 200, body: { data: [{ name: 'Site', url: 'https://example.com' }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.manga(1).external[:data]).to be_a(Array)
+      end
+    end
+  end
+end

--- a/spec/jikanrb/resources/person_resource_spec.rb
+++ b/spec/jikanrb/resources/person_resource_spec.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+RSpec.describe Jikanrb::Resources::PersonResource do
+  subject(:resource) { described_class.new(client, person_id) }
+
+  let(:client) { Jikanrb::Client.new }
+  let(:person_id) { 1 }
+  let(:base_url) { 'https://api.jikan.moe/v4' }
+
+  describe '#initialize' do
+    it 'stores the client reference' do
+      expect(resource.instance_variable_get(:@client)).to eq(client)
+    end
+
+    it 'stores the person ID' do
+      expect(resource.instance_variable_get(:@id)).to eq(person_id)
+    end
+  end
+
+  describe '#info' do
+    context 'when fetching basic info' do
+      let(:response_body) do
+        {
+          data: {
+            mal_id: 1,
+            name: 'Tomokazu Seki',
+            given_name: '智一',
+            family_name: '関'
+          }
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "#{base_url}/people/#{person_id}")
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns person details as hash' do
+        expect(resource.info).to be_a(Hash)
+      end
+
+      it 'returns correct mal_id with symbol access' do
+        expect(resource.info[:data][:mal_id]).to eq(1)
+      end
+
+      it 'returns correct name with string access' do
+        expect(resource.info['data']['name']).to eq('Tomokazu Seki')
+      end
+    end
+
+    context 'when fetching full info' do
+      let(:response_body) do
+        {
+          data: {
+            mal_id: 1,
+            name: 'Tomokazu Seki',
+            voices: [],
+            anime: [],
+            manga: []
+          }
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "#{base_url}/people/#{person_id}/full")
+          .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns extended person details' do
+        result = resource.info(full: true)
+
+        expect(result[:data][:mal_id]).to eq(1)
+        expect(result[:data][:voices]).to be_a(Array)
+        expect(result[:data][:anime]).to be_a(Array)
+      end
+    end
+  end
+
+  describe '#animes' do
+    let(:response_body) do
+      {
+        data: [
+          { position: 'Director', anime: { mal_id: 1, title: 'Cowboy Bebop' } },
+          { position: 'Producer', anime: { mal_id: 5, title: 'Cowboy Bebop: Tengoku no Tobira' } }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/people/#{person_id}/anime")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it "returns person's anime staff positions as array" do
+      result = resource.animes
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].first[:position]).to eq('Director')
+    end
+
+    it 'supports both symbol and string access' do
+      expect(resource.animes['data'].first['anime']['title']).to eq('Cowboy Bebop')
+    end
+  end
+
+  describe '#mangas' do
+    let(:response_body) do
+      {
+        data: [
+          { position: 'Story & Art', manga: { mal_id: 1, title: 'Monster' } }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/people/#{person_id}/manga")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it "returns person's manga work positions" do
+      result = resource.mangas
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].first[:position]).to eq('Story & Art')
+    end
+
+    it 'supports string access' do
+      expect(resource.mangas['data'].first['manga']['title']).to eq('Monster')
+    end
+  end
+
+  describe '#voices' do
+    let(:response_body) do
+      {
+        data: [
+          { role: 'Main', character: { mal_id: 1, name: 'Spike Spiegel' },
+            anime: { mal_id: 1, title: 'Cowboy Bebop' } },
+          { role: 'Supporting', character: { mal_id: 100, name: 'Another Character' },
+            anime: { mal_id: 20, title: 'Naruto' } }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/people/#{person_id}/voices")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it "returns person's voice acting roles" do
+      result = resource.voices
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:role]).to eq('Main')
+    end
+
+    it 'includes character and anime information' do
+      result = resource.voices
+
+      expect(result[:data].first[:character][:name]).to eq('Spike Spiegel')
+      expect(result['data'].first['anime']['title']).to eq('Cowboy Bebop')
+    end
+  end
+
+  describe '#pictures' do
+    let(:response_body) do
+      {
+        data: [
+          { jpg: { image_url: 'https://cdn.myanimelist.net/images/voiceactors/1/123.jpg' } },
+          { jpg: { image_url: 'https://cdn.myanimelist.net/images/voiceactors/1/456.jpg' } }
+        ]
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, "#{base_url}/people/#{person_id}/pictures")
+        .to_return(status: 200, body: response_body, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it "returns person's pictures" do
+      result = resource.pictures
+
+      expect(result[:data]).to be_a(Array)
+      expect(result[:data].length).to eq(2)
+      expect(result[:data].first[:jpg][:image_url]).to include('myanimelist.net')
+    end
+  end
+
+  describe 'Client#person fluent API integration' do
+    describe '#person' do
+      it 'returns a PersonResource instance' do
+        expect(client.person(1)).to be_a(described_class)
+      end
+
+      it 'passes the correct ID to the resource' do
+        expect(client.person(123).instance_variable_get(:@id)).to eq(123)
+      end
+
+      it 'passes the client reference to the resource' do
+        expect(client.person(1).instance_variable_get(:@client)).to eq(client)
+      end
+    end
+
+    describe 'fluent chaining' do
+      it 'allows chaining .person(id).info' do
+        stub_request(:get, "#{base_url}/people/1")
+          .to_return(status: 200, body: { data: { mal_id: 1, name: 'Tomokazu Seki' } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.person(1).info[:data][:name]).to eq('Tomokazu Seki')
+      end
+
+      it 'allows chaining .person(id).info(full: true)' do
+        stub_request(:get, "#{base_url}/people/1/full")
+          .to_return(status: 200, body: { data: { mal_id: 1, name: 'Tomokazu Seki', voices: [] } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.person(1).info(full: true)[:data][:voices]).to be_a(Array)
+      end
+
+      it 'allows chaining .person(id).animes' do
+        stub_request(:get, "#{base_url}/people/1/anime")
+          .to_return(status: 200, body: { data: [{ position: 'Director', anime: { mal_id: 1 } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.person(1).animes[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .person(id).mangas' do
+        stub_request(:get, "#{base_url}/people/1/manga")
+          .to_return(status: 200, body: { data: [{ position: 'Author', manga: { mal_id: 1 } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.person(1).mangas[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .person(id).voices' do
+        stub_request(:get, "#{base_url}/people/1/voices")
+          .to_return(status: 200, body: { data: [{ role: 'Main', character: { mal_id: 1 } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.person(1).voices[:data]).to be_a(Array)
+      end
+
+      it 'allows chaining .person(id).pictures' do
+        stub_request(:get, "#{base_url}/people/1/pictures")
+          .to_return(status: 200, body: { data: [{ jpg: { image_url: 'https://example.com/pic.jpg' } }] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        expect(client.person(1).pictures[:data]).to be_a(Array)
+      end
+    end
+  end
+end

--- a/spec/jikanrb_spec.rb
+++ b/spec/jikanrb_spec.rb
@@ -107,14 +107,14 @@ RSpec.describe Jikanrb do
 
     describe '.character' do
       it 'delegates to client.character' do
-        expect(mock_client).to receive(:character).with(1, full: false)
+        expect(mock_client).to receive(:character).with(1)
         described_class.character(1)
       end
     end
 
     describe '.person' do
       it 'delegates to client.person' do
-        expect(mock_client).to receive(:person).with(1, full: false)
+        expect(mock_client).to receive(:person).with(1)
         described_class.person(1)
       end
     end

--- a/spec/jikanrb_spec.rb
+++ b/spec/jikanrb_spec.rb
@@ -88,19 +88,14 @@ RSpec.describe Jikanrb do
 
     describe '.anime' do
       it 'delegates to client.anime' do
-        expect(mock_client).to receive(:anime).with(1, full: false)
+        expect(mock_client).to receive(:anime).with(1)
         described_class.anime(1)
-      end
-
-      it 'passes full parameter' do
-        expect(mock_client).to receive(:anime).with(1, full: true)
-        described_class.anime(1, full: true)
       end
     end
 
     describe '.manga' do
       it 'delegates to client.manga' do
-        expect(mock_client).to receive(:manga).with(1, full: false)
+        expect(mock_client).to receive(:manga).with(1)
         described_class.manga(1)
       end
     end


### PR DESCRIPTION
## Summary

Implements the Fluent API for accessing sub-resources with chainable methods.

## New Features

### Fluent API Resources

| Resource | Methods |
|----------|---------|
| `AnimeResource` | `info`, `characters`, `staff`, `episodes`, `news`, `forum`, `videos`, `pictures`, `statistics`, `recommendations`, `relations`, `themes`, `external`, `streaming` |
| `MangaResource` | `info`, `characters`, `news`, `forum`, `pictures`, `statistics`, `recommendations`, `relations`, `external` |
| `CharacterResource` | `info`, `animes`, `mangas`, `voices`, `pictures` |
| `PersonResource` | `info`, `animes`, `mangas`, `voices`, `pictures` |

### Usage

```ruby
client = Jikanrb::Client.new

# Anime
client.anime(1).info
client.anime(1).characters
client.anime(1).episodes(page: 2)

# Manga
client.manga(1).info(full: true)
client.manga(1).statistics

# Character
client.character(1).voices

# Person
client.person(1).animes
```

## Breaking Changes

```ruby
# Before (v0.2.x)
client.anime(1)

# After (v0.3.0)
client.anime(1).info
```

## Included PRs
- #10 - BaseResource infrastructure
- #11 - Character and Person resources
- #14 - Documentation and version bump

## Verification
- 240 tests passing
- RuboCop: 0 offenses
- YARD: 96.95% documented
